### PR TITLE
Source template variable restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,45 @@ VAR=abc
 Any number of `--strict` flags can be provided.
 No more forgotten template overrides or missing env vars!
 
+### Source templates
+
+You can use an env template as a source template by using the `-s` or `--source` argument. This will restrict any non-prefixed variables found in the environment to only those already defined in your template.
+
+```bash
+$ cat template.env
+ANSWER=13
+TOKEN=very secret string
+VALUE=0
+```
+
+```bash
+$ export ANSWER='42'
+$ dump-env --source=template.env
+ANSWER=42
+TOKEN=very secret string
+VALUE=0
+```
+
+You can still also use prefixes to add extra variables from the environment
+
+```bash
+$ export EXTRA_VAR='foo'
+$ dump-env -s template.env -p EXTRA_
+ANSWER=13
+TOKEN=very secret string
+VALUE=0
+VAR=foo
+```
+
+#### Strict Source
+
+Using the `--strict-source` flag has the same effect as defining a `--strict` flag for every variable defined in the source template.
+
+```bash
+$ export ANSWER='42'
+$ dump-env -s template.env --strict-source
+Missing env vars: TOKEN, VALUE
+```
 
 ## Creating secret variables in some CIs
 

--- a/dump_env/cli.py
+++ b/dump_env/cli.py
@@ -30,6 +30,18 @@ def _create_parser() -> argparse.ArgumentParser:
         action='append',
         help='Strict variables should exists in os envs',
     )
+    parser.add_argument(
+        '-s',
+        '--source',
+        default='',
+        type=str,
+        help='Source template path, restricts non-prefixed env vars',
+    )
+    parser.add_argument(
+        '--strict-source',
+        action='store_true',
+        help='All source template variables should exist in os envs',
+    )
     return parser
 
 
@@ -70,12 +82,32 @@ def main() -> NoReturn:
 
             $ dump-env --strict=REQUIRED
 
+        This example will dump everything from a source ``.env.template`` file
+        with only env variables that are defined in the file:
+
+        .. code:: bash
+
+            $ dump-env -s .env.template
+
+        This example will fail if any keys in the source template do not exist
+        in the environment:
+
+        .. code:: bash
+
+            $ dump-env -s .env.template --strict-source
+
     """
     args = _create_parser().parse_args()
     strict_vars = set(args.strict) if args.strict else None
 
     try:
-        variables = dumper.dump(args.template, args.prefix, strict_vars)
+        variables = dumper.dump(
+            args.template,
+            args.prefix,
+            strict_vars,
+            args.source,
+            args.strict_source,
+        )
     except StrictEnvException as exc:
         sys.stderr.write('{0}\n'.format(str(exc)))
         sys.exit(1)

--- a/tests/test_cli/test_source.py
+++ b/tests/test_cli/test_source.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+import delegator
+
+
+def test_source_vars(monkeypatch, env_file):
+    """Check that cli shows only source variables."""
+    monkeypatch.setenv('NORMAL_KEY', '1')
+    monkeypatch.setenv('EXTRA_VALUE', '2')
+
+    variables = delegator.run('dump-env -s {0}'.format(env_file))
+    assert variables.out == 'NORMAL_KEY=1\n'
+    assert variables.subprocess.returncode == 0
+
+
+def test_source_prefixes(monkeypatch, env_file):
+    """Check that cli allows prefixes with source."""
+    monkeypatch.setenv('NORMAL_KEY', '1')
+    monkeypatch.setenv('EXTRA_VALUE', '2')
+
+    variables = delegator.run('dump-env -p EXTRA_ -s {0}'.format(env_file))
+    assert variables.out == 'NORMAL_KEY=1\nVALUE=2\n'
+    assert variables.subprocess.returncode == 0
+
+
+def test_source_strict(monkeypatch, env_file):
+    """Check that cli works correctly with strict-source."""
+    monkeypatch.setenv('NORMAL_KEY', '1')
+    monkeypatch.setenv('EXTRA_VALUE', '2')
+
+    variables = delegator.run(
+        'dump-env --strict-source -s {0}'.format(env_file),
+    )
+    assert variables.out == 'NORMAL_KEY=1\n'
+    assert variables.subprocess.returncode == 0
+
+
+def test_source_strict_fail(monkeypatch, env_file):
+    """Check that cli works correctly with strict-source missing keys."""
+    monkeypatch.setenv('EXTRA_VALUE', '2')
+
+    variables = delegator.run(
+        'dump-env --strict-source -s {0}'.format(env_file),
+    )
+    assert variables.err == 'Missing env vars: NORMAL_KEY\n'
+    assert variables.subprocess.returncode == 1


### PR DESCRIPTION
Related to #109 - allows a template file to act as the base list of included environment variables, and optionally enforce them all as strict requirements.

See README.md changes for documentation.


I've not used poetry before and was unable to get it running in my environment, so I was unable to run all of the steps in the contributing guide. Please forgive me :pray: I've done my best to match surrounding styles